### PR TITLE
Add missing class to "provides" section

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,8 @@
   "license": "Artistic-2.0",
   "provides": {
     "StaticTable": "lib/Data/StaticTable.pm6",
-    "StaticTable::Query": "lib/Data/StaticTable.pm6"
+    "StaticTable::Query": "lib/Data/StaticTable.pm6",
+    "X::Data::StaticTable": "lib/X/Data/StaticTable.pm6"
   },
   "version": "0.1.0",
   "tags" : [ "data", "table", "bidimensional", "spreadsheet" , "static", "immutable", "cells", "rows", "columns"],


### PR DESCRIPTION
I think `Data::StaticTable::Position` also needs to be listed, but I've not checked whether that type is actually exported and what it's final name is.