### PR TITLE
Match the right $_ under v6.d

### DIFF
--- a/lib/Data/StaticTable.pm6
+++ b/lib/Data/StaticTable.pm6
@@ -317,12 +317,12 @@ class StaticTable::Query {
         X::Data::StaticTable.new("Method grep only accepts one adverb at a time").throw unless one($n, $r, $default, $nr, $nh) == True;
         my Data::StaticTable::Position @rownums;
         if (%!indexes{$heading}:exists) { #-- Search in the index if it is available. Should be faster.
-            my @keysearch = grep {.defined and $matcher}, %!indexes{$heading}.keys;
+            my @keysearch = grep {.defined and $_ ~~ $matcher}, %!indexes{$heading}.keys;
             for (@keysearch) -> $k {
                 @rownums.push(|%!indexes{$heading}{$k});
             }
         } else {;
-            @rownums = 1 <<+>> ( grep {.defined and $matcher}, :k, $!T.column($heading) );
+            @rownums = 1 <<+>> ( grep {.defined and $_ ~~ $matcher}, :k, $!T.column($heading) );
         }
         if ($n) { # Returning rowlist
             return @rownums.sort.list                           #-- :n


### PR DESCRIPTION
A regex in boolean context per v6.d captures the $_ at the point where
the regex literal appears. These two lines will stop working in
upcoming rakudo releases. There are two ways to fix it. One is to put
`use v6.c` in appropriate places, which will provide previous
behavior. Another is to match $_ explicitly so that it works for all
versions. The latter approach is used here.